### PR TITLE
Fix cape and add transparent background option

### DIFF
--- a/minepi/skin.py
+++ b/minepi/skin.py
@@ -40,8 +40,7 @@ class Skin:
         self._skin: Optional[Image.Image] = None
         self._head: Optional[Image.Image] = None
 
-        if raw_cape is not None:
-            self.set_cape(raw_cape)
+        self.set_cape(raw_cape)
 
         if self._raw_skin.mode != "RGBA":  # Converting skins to RGBA
             self._raw_skin = self._raw_skin.convert(mode="RGBA")
@@ -218,6 +217,7 @@ class Skin:
             display_second_layer: bool = True,
             display_cape: bool = True,
             aa: bool = False,
+            transparent_background: bool = False,
     ) -> Optional[Image.Image]:
         """Render a full body skin
 
@@ -272,6 +272,7 @@ class Skin:
             display_layers=display_second_layer,
             display_cape=display_cape,
             aa=aa,
+            transparent_background=transparent_background,
         )
         im = await render.get_render()
         self._skin = im

--- a/minepi/skin_render.py
+++ b/minepi/skin_render.py
@@ -54,6 +54,7 @@ class Render:
             display_layers: bool = False,
             display_cape: bool = False,
             aa: bool = False,
+            transparent_background: bool = False,
     ):
         self.vr = vr
         self.hr = hr
@@ -70,6 +71,7 @@ class Render:
         self.layers = display_layers
         self.player = player
         self.aa = aa
+        self.transparent_background = transparent_background
         self.rendered_image = None
 
         self.loop = asyncio.get_event_loop()
@@ -1691,7 +1693,8 @@ class Render:
         real_width = src_width / 2
         real_height = src_height / 2
 
-        image = Image.new('RGBA', (int(src_width), int(src_height)))
+        color = (0, 0, 0, 0) if self.transparent_background else (0, 0, 0, 1)
+        image = Image.new('RGBA', (int(src_width), int(src_height)), color=color)
 
         display_order = self.get_display_order()
         draw = ImageDraw.Draw(image)


### PR DESCRIPTION
There was an issue not supplying a cape would break rendering:
![image](https://user-images.githubusercontent.com/7473757/217032651-90a0a2f1-339a-4c19-8afb-01fef7ef3de8.png)

Also added a transparent background option.